### PR TITLE
[IMP] Remove unnecessary container

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+2.2.1
+-----
+
+  - [IMP] Remove unnecessary containers
 
 2.2.0
 -----

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DockerT3kit helps you developing t3kit based TYPO3 CMS projects
 
-DockerT3kit creates the necessary Docker containers (webserver, database, php, mail, redis, elasticsearch, couchdb)
-to run your TYPO3 CMS project. The package provides a wrapper script in `vendor/bin/dockert3kit`
+DockerT3kit creates the necessary Docker containers (webserver, database, php, mail and solr)
+to run your t3kit based TYPO3 CMS project. The package provides a wrapper script in `vendor/bin/dockert3kit`
 which simplifies the handling of docker and does all the configuration necessary.
 
 We created this package to make development on TYPO3 CMS projects easier and
@@ -36,7 +36,7 @@ Add `lauri/dockert3kit` as dev dependency in your composer, using the latest sta
 *Example*:
 
 ```
-composer require --dev lauri/dockert3kit '~2.2.0'
+composer require --dev lauri/dockert3kit '~2.2.1'
 ```
 
 *Note*:
@@ -118,7 +118,7 @@ the port accordingly. If you are using PHPStorm, this link may be useful for you
 
     vendor/bin/dockert3kit run SERVICE /bin/bash
 
-SERVICE can currently be `app`, `web`, `data`, `db`, `redis`, `elasticsearch` or `couchdb`.
+SERVICE can currently be `app`, `web`, `data`, `db` or `solr`.
 
 ## Access project url when inside `app` container
 
@@ -151,21 +151,6 @@ To be able to do that, we have mapped database port inside the container (which 
 host machine through `3307` port.
 
 ![Screenshot of MySQL Workbench interface](/docs/MySQL-Workbench.png "MySQL Workbench interface")
-
-## Access CouchDB
-
-From your host machine, you can access couchdb from web interface or command line:
-
-__Web__: [http://hostname-couchdb:5984/_utils/](http://hostname-couchdb:5984/_utils/) -> replace `hostname` with project name
-
-__Cli__: `curl -X GET http://hostname-couchdb:5984/_all_dbs`
-
-From inside your `app` container, you can also access couchdb through the command line:
-
-```
-vendor/bin/dockert3kit run app /bin/bash
-curl -X GET http://couchdb:5984/_all_dbs
-```
 
 ## Access Apache Solr server
 

--- a/config/elasticsearch/config.yml
+++ b/config/elasticsearch/config.yml
@@ -1,9 +1,0 @@
-script.disable_dynamic: sandbox
-script.groovy.sandbox.class_whitelist: java.util.LinkedHashMap
-script.groovy.sandbox.receiver_whitelist: java.util.Iterator, java.lang.Object, java.util.Map, java.util.Map$Entry
-script.groovy.sandbox.enabled: true
-node.name: elasticsearch
-cluster.name: dockertypo3
-network.host: 0.0.0.0
-index.number_of_shards: 1
-index.number_of_replicas: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,6 @@ app:
   links:
     - db
     - mail
-    - redis
-    - elasticsearch
-    - couchdb
     - solr
   environment:
     - HOST_USER_ID
@@ -70,25 +67,6 @@ mail:
   image: mailhog/mailhog:latest
   ports:
     - "8025:8025"
-
-redis:
-  image: redis:3.0
-  ports:
-    - "6379:6379"
-
-elasticsearch:
-  hostname: "${PROJECT_NAME}-elasticsearch"
-  image: elasticsearch:1.4
-  ports:
-    - "9200:9200"
-  volumes:
-    - ./config/elasticsearch/config.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
-
-couchdb:
-  hostname: "${PROJECT_NAME}-couchdb"
-  image: klaemo/couchdb:1.6
-  ports:
-    - "5984:5984"
 
 solr:
   image: writl/solr-typo3:4.10.4-4


### PR DESCRIPTION
t3kit does not use all containers in the Docker kit. This improvement
removes unnecessary containers and by doing so makes it slimmer.
